### PR TITLE
fix "click_lastmatch" is not exported by the testapi module error

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -30,7 +30,7 @@ Base class implementation of distribution class necessary for testapi
 =cut
 
 # don't import script_run - it will overwrite script_run from distribution and create a recursion
-use testapi qw(send_key %cmd assert_screen check_screen check_var click_lastmatch get_var save_screenshot
+use testapi qw(send_key %cmd assert_screen check_screen check_var get_var save_screenshot
   match_has_tag set_var type_password type_string wait_serial $serialdev
   mouse_hide send_key_until_needlematch record_info record_soft_failure
   wait_still_screen wait_screen_change get_required_var diag);
@@ -320,7 +320,7 @@ sub ensure_installed {
         last if (match_has_tag('pkcon-finished'));
         if (match_has_tag('PolicyKit-authenticate')) {
             type_password;
-            click_lastmatch;
+            send_key 'ret';
             @tags = grep { $_ ne 'PolicyKit-authenticate' } @tags;
             @tags = grep { $_ ne 'Policykit-behind-window' } @tags;
             next;


### PR DESCRIPTION
This reverts commit 9e75807222217886e385f7c73a0bd5f598a653b8.

(cherry picked from commit 9fbbb3505d8bfe8376ae4b719d95a0c960a6cd98)

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
